### PR TITLE
Add systems engineering and IEEE 1012 process value sets

### DIFF
--- a/src/valuesets/schema/computing/systems_engineering.yaml
+++ b/src/valuesets/schema/computing/systems_engineering.yaml
@@ -1,0 +1,81 @@
+name: systems_engineering
+title: Systems and Software Engineering Life Cycle Processes
+description: Value sets for the system life cycle processes defined by ISO/IEC/IEEE 15288.
+id: https://w3id.org/valuesets/computing/systems_engineering
+imports:
+- linkml:types
+prefixes:
+  valuesets: https://w3id.org/valuesets/
+  valuesets_meta: https://w3id.org/valuesets/meta/
+default_prefix: valuesets
+
+enums:
+  SystemLifeCycleProcess15288:
+    title: ISO/IEC/IEEE 15288 System Life Cycle Process
+    description: The 30 system life cycle processes grouped by ISO/IEC/IEEE 15288:2015.
+    status: STANDARD
+    instantiates:
+    - valuesets_meta:ReferenceEnumDefinition
+    source: https://www.iso.org/standard/63711.html
+    conforms_to: ISO/IEC/IEEE 15288:2015
+    permissible_values:
+      ACQUISITION:
+        title: Acquisition Process
+      SUPPLY:
+        title: Supply Process
+      LIFE_CYCLE_MODEL_MANAGEMENT:
+        title: Life Cycle Model Management Process
+      INFRASTRUCTURE_MANAGEMENT:
+        title: Infrastructure Management Process
+      PORTFOLIO_MANAGEMENT:
+        title: Portfolio Management Process
+      HUMAN_RESOURCE_MANAGEMENT:
+        title: Human Resource Management Process
+      QUALITY_MANAGEMENT:
+        title: Quality Management Process
+      PROJECT_PLANNING:
+        title: Project Planning Process
+      PROJECT_ASSESSMENT_AND_CONTROL:
+        title: Project Assessment and Control Process
+      DECISION_MANAGEMENT:
+        title: Decision Management Process
+      RISK_MANAGEMENT:
+        title: Risk Management Process
+      CONFIGURATION_MANAGEMENT:
+        title: Configuration Management Process
+      INFORMATION_MANAGEMENT:
+        title: Information Management Process
+      MEASUREMENT:
+        title: Measurement Process
+      QUALITY_ASSURANCE:
+        title: Quality Assurance Process
+      KNOWLEDGE_MANAGEMENT:
+        title: Knowledge Management Process
+      BUSINESS_OR_MISSION_ANALYSIS:
+        title: Business or Mission Analysis Process
+      STAKEHOLDER_NEEDS_AND_REQUIREMENTS_DEFINITION:
+        title: Stakeholder Needs and Requirements Definition Process
+      SYSTEM_REQUIREMENTS_DEFINITION:
+        title: System Requirements Definition Process
+      ARCHITECTURE_DEFINITION:
+        title: Architecture Definition Process
+      DESIGN_DEFINITION:
+        title: Design Definition Process
+      SYSTEM_ANALYSIS:
+        title: System Analysis Process
+      IMPLEMENTATION:
+        title: Implementation Process
+      INTEGRATION:
+        title: Integration Process
+      VERIFICATION:
+        title: Verification Process
+      TRANSITION:
+        title: Transition Process
+      VALIDATION:
+        title: Validation Process
+      OPERATION:
+        title: Operation Process
+      MAINTENANCE:
+        title: Maintenance Process
+      DISPOSAL:
+        title: Disposal Process

--- a/src/valuesets/schema/computing/verification_validation_ieee_1012.yaml
+++ b/src/valuesets/schema/computing/verification_validation_ieee_1012.yaml
@@ -1,0 +1,39 @@
+name: verification_validation_ieee_1012
+title: IEEE 1012 Verification and Validation Processes
+description: Value sets for system, software, and hardware verification and validation activities defined by IEEE 1012.
+id: https://w3id.org/valuesets/computing/verification_validation_ieee_1012
+imports:
+- linkml:types
+prefixes:
+  valuesets: https://w3id.org/valuesets/
+  valuesets_meta: https://w3id.org/valuesets/meta/
+default_prefix: valuesets
+
+enums:
+  VerificationValidationProcessIEEE1012:
+    title: IEEE 1012 Verification and Validation Process
+    description: Verification and validation processes applied across the system, software, and hardware life cycle.
+    status: STANDARD
+    instantiates:
+    - valuesets_meta:ReferenceEnumDefinition
+    source: https://standards.ieee.org/standard/1012-2016.html
+    conforms_to: IEEE 1012-2016
+    permissible_values:
+      CONCEPT_AND_REQUIREMENTS_V_AND_V:
+        title: Concept and Requirements Verification and Validation
+      ARCHITECTURE_AND_DESIGN_V_AND_V:
+        title: Architecture and Design Verification and Validation
+      IMPLEMENTATION_V_AND_V:
+        title: Implementation Verification and Validation
+      INTEGRATION_V_AND_V:
+        title: Integration Verification and Validation
+      QUALIFICATION_TESTING:
+        title: Qualification Testing
+      INSTALLATION_AND_CHECKOUT:
+        title: Installation and Checkout Verification and Validation
+      OPERATION_V_AND_V:
+        title: Operation Verification and Validation
+      MAINTENANCE_V_AND_V:
+        title: Maintenance Verification and Validation
+      DISPOSAL_V_AND_V:
+        title: Disposal Verification and Validation

--- a/src/valuesets/schema/valuesets.yaml
+++ b/src/valuesets/schema/valuesets.yaml
@@ -121,6 +121,8 @@ imports:
 - units/quantity_kinds
 - computing/file_formats
 - computing/maturity_levels
+- computing/systems_engineering
+- computing/verification_validation_ieee_1012
 - computing/ontologies
 - computing/croissant_ml
 - business/organizational_structures


### PR DESCRIPTION
## Summary

- Add the 30 ISO/IEC/IEEE 15288 system life cycle processes.
- Add IEEE 1012 system, software, and hardware verification and validation processes.
- Import both value sets into the main schema.

## Validation

- `just site` completed for the 15288 addition.
- A subsequent `just site` run was started after the IEEE 1012 addition but interrupted during lengthy project generation; generated artifacts were cleaned up.
- `just validate` was attempted but interrupted during large ontology database downloads.